### PR TITLE
fixed hardcoded image size bug

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -1123,7 +1123,7 @@ class ONNX_TRT_ROIALIGN2(nn.Module):
         self.mask_resolution = mask_resolution
         self.pooler_scale = pooler_scale
         self.sampling_ratio = sampling_ratio
-        self.image_size = 640
+        self.image_size = max_wh
         self.roi_align_type = 2  # 1, or 2
 
         self.background_class = (-1,)


### PR DESCRIPTION
There was a problem with the onnx export with a custom image size. This PR fixes the issue https://github.com/hiennguyen9874/deepstream-realtime-instance-segmentation/issues/4 